### PR TITLE
Allow access of body variables

### DIFF
--- a/lib/Authy/AuthyResponse.php
+++ b/lib/Authy/AuthyResponse.php
@@ -88,4 +88,14 @@ class AuthyResponse
     {
         return $this->body->message;
     }
+
+    /**
+     * Returns the variable specified in the response if present
+     *
+     * @return value
+     */
+    public function bodyvar($var)
+    {
+        return isset($this->body->$var) ? $this->body->$var: null;
+    }
 }


### PR DESCRIPTION
Hello,

We were experiencing some issues with the PHP API of your (awesome!) client.

The provided variables weren't accessible after making the calls.
For instance:
We needed the (secured) phonenumber in our application, but this wasn't accessible through the API although it was in the raw result.

I've created this update to solve this issue for us, it may be an interesting update for your repos.

Regards, Michiel